### PR TITLE
wrong example mint/mate/64 -> mint/64/mate

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Then run buildlive script as follows, suppose your USB is /dev/sdb and /dev/sdb1
 
 ```
 # install Arch, Mint (x86_64 with MATE Desktop) and Fedora to USB
-./buildlive --root=/media/sdb1 --dev=/dev/sdb arch mint/mate/64 fedora
+./buildlive --root=/media/sdb1 --dev=/dev/sdb arch mint/64/mate fedora
 ```
 
 ## status


### PR DESCRIPTION
The provided example did not work, as the folder structure is mint/64/DE not mint/DE/64
Fixed this in the readme example.
