### PR TITLE
distro: add Manjaro Architect

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ First mount your USB drive partition. I recommend using udevil so that you can w
 
 Then run buildlive script as follows, suppose your USB is /dev/sdb and /dev/sdb1 is mount to /media/sdb1:
 
-```
+```bash
 # install Arch, Mint (x86_64 with MATE Desktop) and Fedora 28 to USB
 ./buildlive --root=/media/sdb1 --dev=/dev/sdb arch mint/64/mate fedora/28
 ```

--- a/distro/manjaro/architect/entry
+++ b/distro/manjaro/architect/entry
@@ -1,0 +1,3 @@
+_arch=x86_64
+_flavour=ARCHITECT
+source distro/manjaro/entry

--- a/distro/manjaro/architect/install.sh
+++ b/distro/manjaro/architect/install.sh
@@ -1,0 +1,2 @@
+ARCH=x86_64
+source distro/manjaro/install.sh

--- a/distro/manjaro/architect/isoinfo
+++ b/distro/manjaro/architect/isoinfo
@@ -1,0 +1,9 @@
+_isodate=18.0
+
+ISONAME="$DISTRONAME x86_64 $_isodate ARCHITECT"
+ISOURL=manjaro-architect-${_isodate}-stable-x86_64.iso
+SHA256=44363436c53fe536c82aeaa65e1afea44cb5091d4817f424fd96b061566090b7
+
+mirrorlist=(
+http://osdn.dl.osdn.jp/storage/g/m/ma/manjaro/architect/18.0
+)


### PR DESCRIPTION
Add Manjaro Architect distro and missing "bash" marker to README.md, that enables proper syntax highlighting on GitHub.